### PR TITLE
Fix flaky test

### DIFF
--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -91,21 +92,29 @@ public class JacksonUtilsTest {
                 "[{\"key\":\"value\"}]".getBytes(),
                 JacksonUtils.toJsonBytes(Collections.singletonList(Collections.singletonMap("key", "value")))
         );
-        Assert.assertArrayEquals(
-                "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes(),
-                JacksonUtils.toJsonBytes(new TestOfAtomicObject())
-        );
+        byte[] expectedAtomicObject = "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes();
+        Arrays.sort(expectedAtomicObject); //sorting the byte array
+
+        byte[] actualAtomicObject = JacksonUtils.toJsonBytes(new TestOfAtomicObject());
+        Arrays.sort(actualAtomicObject); //sorting the byte array
+
+        Assert.assertArrayEquals(expectedAtomicObject, actualAtomicObject);
+
         Assert.assertArrayEquals("{\"date\":1626192000000}".getBytes(), JacksonUtils.toJsonBytes(new TestOfDate()));
         // only public
         Assert.assertArrayEquals(
                 "{\"publicAccessModifier\":\"public\"}".getBytes(),
                 JacksonUtils.toJsonBytes(new TestOfAccessModifier())
         );
+
+        byte[] expectedTestOfGetter = "{\"value\":\"value\",\"key\":\"key\"}".getBytes();
+        Arrays.sort(expectedTestOfGetter); //sorting the byte array
+
+        byte[] actualTestOfGetter = JacksonUtils.toJsonBytes(new TestOfGetter());
+        Arrays.sort(actualTestOfGetter); //sorting the byte array
+
         // getter is also recognized
-        Assert.assertArrayEquals(
-                "{\"value\":\"value\",\"key\":\"key\"}".getBytes(),
-                JacksonUtils.toJsonBytes(new TestOfGetter())
-        );
+        Assert.assertArrayEquals(expectedTestOfGetter, actualTestOfGetter);
         // annotation available
         Assert.assertArrayEquals(
                 ("{\"@type\":\"JacksonUtilsTest$TestOfAnnotationSub\",\"date\":\"2021-07-14\",\"subField\":\"subField\"," 

--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Assert;
@@ -39,7 +40,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -92,13 +92,8 @@ public class JacksonUtilsTest {
                 "[{\"key\":\"value\"}]".getBytes(),
                 JacksonUtils.toJsonBytes(Collections.singletonList(Collections.singletonMap("key", "value")))
         );
-        byte[] expectedAtomicObject = "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes();
-        Arrays.sort(expectedAtomicObject); //sorting the byte array
 
-        byte[] actualAtomicObject = JacksonUtils.toJsonBytes(new TestOfAtomicObject());
-        Arrays.sort(actualAtomicObject); //sorting the byte array
-
-        Assert.assertArrayEquals(expectedAtomicObject, actualAtomicObject);
+        Assert.assertArrayEquals("{\"aBoolean\":false,\"aInteger\":1,\"aLong\":0}".getBytes(), JacksonUtils.toJsonBytes(new TestOfAtomicObject()));
 
         Assert.assertArrayEquals("{\"date\":1626192000000}".getBytes(), JacksonUtils.toJsonBytes(new TestOfDate()));
         // only public
@@ -107,14 +102,8 @@ public class JacksonUtilsTest {
                 JacksonUtils.toJsonBytes(new TestOfAccessModifier())
         );
 
-        byte[] expectedTestOfGetter = "{\"value\":\"value\",\"key\":\"key\"}".getBytes();
-        Arrays.sort(expectedTestOfGetter); //sorting the byte array
-
-        byte[] actualTestOfGetter = JacksonUtils.toJsonBytes(new TestOfGetter());
-        Arrays.sort(actualTestOfGetter); //sorting the byte array
-
         // getter is also recognized
-        Assert.assertArrayEquals(expectedTestOfGetter, actualTestOfGetter);
+        Assert.assertArrayEquals("{\"key\":\"key\",\"value\":\"value\"}".getBytes(), JacksonUtils.toJsonBytes(new TestOfGetter()));
         // annotation available
         Assert.assertArrayEquals(
                 ("{\"@type\":\"JacksonUtilsTest$TestOfAnnotationSub\",\"date\":\"2021-07-14\",\"subField\":\"subField\"," 
@@ -482,7 +471,8 @@ public class JacksonUtilsTest {
         Assert.assertEquals("你好，中国！", restResult.getData().get("string"));
         Assert.assertEquals(999, restResult.getData().get("integer"));
     }
-    
+
+    @JsonPropertyOrder(alphabetic = true)
     static class TestOfAtomicObject {
         
         public AtomicLong aLong = new AtomicLong(0);
@@ -566,7 +556,8 @@ public class JacksonUtilsTest {
             return result;
         }
     }
-    
+
+    @JsonPropertyOrder(alphabetic = true)
     static class TestOfGetter {
         
         public String getKey() {


### PR DESCRIPTION


### Description  
Flaky test found using Nondex when running command - 
`mvn -pl common edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.alibaba.nacos.common.utils.JacksonUtilsTest#testToJsonBytes1`
 The build failure logged was 
`[ERROR] testToJsonBytes1(com.alibaba.nacos.common.utils.JacksonUtilsTest)  Time elapsed: 0.244 s  <<< FAILURE!
org.junit.internal.ArrayComparisonFailure: arrays first differed at element [3]; expected:<76> but was:<73>
        at com.alibaba.nacos.common.utils.JacksonUtilsTest.testToJsonBytes1(JacksonUtilsTest.java:94)
Caused by: java.lang.AssertionError: expected:<76> but was:<73>
        at com.alibaba.nacos.common.utils.JacksonUtilsTest.testToJsonBytes1(JacksonUtilsTest.java:94)`

Two assertions were found to be flaky - 
`Assert.assertArrayEquals(
                "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes(),
                JacksonUtils.toJsonBytes(new TestOfAtomicObject())
        );` 

`Assert.assertArrayEquals(
                "{\"value\":\"value\",\"key\":\"key\"}".getBytes(),
                JacksonUtils.toJsonBytes(new TestOfGetter())
        );`

### Investigation        
The classes `TestOfAtomicObject` and `TestOfGetter` do not mention any order for the fields while generating objects. Thus, the assert fails because the order of the fields does not match the expected order of fields and leads to flakiness of the test. The test assertions' expected JSON strings do not follow any order and thus need to be corrected.


### Fixes
To remove this ambiguity, the annotation `JsonPropertyOrder` is helpful. 
The documentation for `JsonPropertyOrder(alphabetic=true)` mentions that the annotation can be used to define ordering (possibly partial) to use when serializing object properties. Properties included in annotation declaration will be serialized first (in defined order), followed by any properties not included in the definition. The parameter `alphabetic=true` ensures that the fields are defined in alphabetical order. The test case is also changed to make sure that the expected JSON strings are also alphabetically ordered.
This fix removes the possibility of `org.junit.internal.ArrayComparisonFailure` and ensures that the test passes. 